### PR TITLE
[APIS-809] use g++ to build cci submodule

### DIFF
--- a/build_cci.sh
+++ b/build_cci.sh
@@ -7,6 +7,7 @@ if [ -f cci-src/cci/.libs/libcascci.a ];then
 fi
 
 cd cci-src
+sed -i "s/^AM_PROG_CC_C_O/AM_PROG_CC_C_O\nCC=g++/" configure.ac
 chmod +x configure
 chmod +x external/libregex38a/configure
 if [ "$1" = 'x86' ];then
@@ -16,3 +17,4 @@ else
 fi
 
 make
+sed -i "^/CC=g++/d" configure.ac


### PR DESCRIPTION
* cci submodule should be built by g++